### PR TITLE
refactor: Repository 관련 리팩터링

### DIFF
--- a/src/main/java/com/ll/commars/domain/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ll/commars/domain/community/comment/repository/CommentRepository.java
@@ -5,11 +5,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.community.comment.entity.Comment;
 
-@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.board.id = :boardId")

--- a/src/main/java/com/ll/commars/domain/community/comment/repository/ReplyRepository.java
+++ b/src/main/java/com/ll/commars/domain/community/comment/repository/ReplyRepository.java
@@ -3,11 +3,9 @@ package com.ll.commars.domain.community.comment.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.community.comment.entity.Reply;
 
-@Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
 	List<Reply> findByCommentId(Long commentId);

--- a/src/main/java/com/ll/commars/domain/community/reaction/repository/ReactionRepository.java
+++ b/src/main/java/com/ll/commars/domain/community/reaction/repository/ReactionRepository.java
@@ -1,13 +1,11 @@
 package com.ll.commars.domain.community.reaction.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.community.board.entity.Board;
 import com.ll.commars.domain.community.reaction.entity.Reaction;
 import com.ll.commars.domain.user.user.entity.User;
 
-@Repository
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
 	// 특정 유저가 특정 게시글에 반응(좋아요/싫어요)을 남겼는지 확인

--- a/src/main/java/com/ll/commars/domain/restaurant/businessHour/repository/BusinessHourRepository.java
+++ b/src/main/java/com/ll/commars/domain/restaurant/businessHour/repository/BusinessHourRepository.java
@@ -1,11 +1,9 @@
 package com.ll.commars.domain.restaurant.businessHour.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.restaurant.businessHour.entity.BusinessHour;
 
-@Repository
 public interface BusinessHourRepository extends JpaRepository<BusinessHour, Long> {
 
 }

--- a/src/main/java/com/ll/commars/domain/restaurant/category/repository/RestaurantCategoryRepository.java
+++ b/src/main/java/com/ll/commars/domain/restaurant/category/repository/RestaurantCategoryRepository.java
@@ -1,11 +1,9 @@
 package com.ll.commars.domain.restaurant.category.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.restaurant.category.entity.RestaurantCategory;
 
-@Repository
 public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCategory, Long> {
 
 }

--- a/src/main/java/com/ll/commars/domain/restaurant/menu/repository/RestaurantMenuRepository.java
+++ b/src/main/java/com/ll/commars/domain/restaurant/menu/repository/RestaurantMenuRepository.java
@@ -5,12 +5,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.restaurant.menu.dto.RestaurantMenuDto;
 import com.ll.commars.domain.restaurant.menu.entity.RestaurantMenu;
 
-@Repository
 public interface RestaurantMenuRepository extends JpaRepository<RestaurantMenu, Long> {
 
 	//List<RestaurantMenuDto.MenuInfo> findByRestaurantId(Long id);

--- a/src/main/java/com/ll/commars/domain/restaurant/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/ll/commars/domain/restaurant/restaurant/repository/RestaurantRepository.java
@@ -6,11 +6,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.restaurant.restaurant.entity.Restaurant;
 
-@Repository
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
 	@Query("SELECT r FROM Restaurant r LEFT JOIN FETCH r.restaurantMenus")

--- a/src/main/java/com/ll/commars/domain/restaurant/restaurantDoc/repository/RestaurantDocRepository.java
+++ b/src/main/java/com/ll/commars/domain/restaurant/restaurantDoc/repository/RestaurantDocRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.restaurant.restaurantDoc.document.RestaurantDoc;
 
-@Repository
 public interface RestaurantDocRepository extends ElasticsearchRepository<RestaurantDoc, String> {
 
 	// name에 2배 가중치

--- a/src/main/java/com/ll/commars/domain/review/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ll/commars/domain/review/review/repository/ReviewRepository.java
@@ -5,12 +5,10 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.review.review.entity.Review;
 import com.ll.commars.domain.reviewerRank.dto.ReviewerRank;
 
-@Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	//    @Query("SELECT r FROM Review r JOIN FETCH r.user WHERE r.restaurant = :restaurant")

--- a/src/main/java/com/ll/commars/domain/review/reviewDoc/repository/ReviewDocRepository.java
+++ b/src/main/java/com/ll/commars/domain/review/reviewDoc/repository/ReviewDocRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.review.reviewDoc.document.ReviewDoc;
 
-@Repository
 public interface ReviewDocRepository extends ElasticsearchRepository<ReviewDoc, String> {
 
 	@Query("""

--- a/src/main/java/com/ll/commars/domain/reviewerRank/repository/ReviewerRepository.java
+++ b/src/main/java/com/ll/commars/domain/reviewerRank/repository/ReviewerRepository.java
@@ -1,11 +1,9 @@
 package com.ll.commars.domain.reviewerRank.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.review.review.entity.Review;
 
-@Repository
 public interface ReviewerRepository extends JpaRepository<Review, Long> {
 
 	//    // ✅ 상위 10명의 리뷰어 조회 (LIMIT 제거 및 Pageable 추가)

--- a/src/main/java/com/ll/commars/domain/user/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/ll/commars/domain/user/favorite/repository/FavoriteRepository.java
@@ -6,12 +6,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.ll.commars.domain.user.favorite.entity.Favorite;
 import com.ll.commars.domain.user.user.entity.User;
 
-@Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
 	// 특정 리뷰어(email)의 찜 목록을 조회


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- resolves: #1 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

깃허브 액션이 안 돌길래 visibility를 public으로 설정했더니 fork가 풀리고, 어쩌다 보니 실수로 레파지토리를 날려 작업 내용이 다 날라갔다.
브랜치는 #9 이슈를 가리키나, 현재 #1 이슈를 가리키고 있다.

이후 도메인 별로 리팩터링을 진행하려고 한다.

- 먼저 불필요한 `@Repository` 를 제거한다. 어차피 `JpaRepository` 나 `ElasticsearchRepository` 는 최상위에 `Repository` 인터페이스가 존재하며, JPA가 알아서 빈으로 등록한다. 

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
