### PR TITLE
refactor: OAuth 로그인 리팩터링

### DIFF
--- a/src/main/java/com/ll/commars/domain/auth/dto/OAuthResponse.java
+++ b/src/main/java/com/ll/commars/domain/auth/dto/OAuthResponse.java
@@ -1,0 +1,4 @@
+package com.ll.commars.domain.auth.dto;
+
+public record OAuthResponse() {
+}

--- a/src/main/java/com/ll/commars/domain/auth/oauth/client/GoogleClient.java
+++ b/src/main/java/com/ll/commars/domain/auth/oauth/client/GoogleClient.java
@@ -1,0 +1,22 @@
+package com.ll.commars.domain.auth.oauth.client;
+
+import com.ll.commars.domain.auth.dto.OAuthResponse;
+import com.ll.commars.domain.member.entity.ProviderType;
+
+public class GoogleClient implements OAuthClient {
+
+	@Override
+	public ProviderType getProviderType() {
+		return ProviderType.GOOGLE;
+	}
+
+	@Override
+	public String getAccessToken(String authorizationCode) {
+		return null;
+	}
+
+	@Override
+	public OAuthResponse getUserInfo(String accessToken) {
+		return null;
+	}
+}

--- a/src/main/java/com/ll/commars/domain/auth/oauth/client/KakaoClient.java
+++ b/src/main/java/com/ll/commars/domain/auth/oauth/client/KakaoClient.java
@@ -1,0 +1,22 @@
+package com.ll.commars.domain.auth.oauth.client;
+
+import com.ll.commars.domain.auth.dto.OAuthResponse;
+import com.ll.commars.domain.member.entity.ProviderType;
+
+public class KakaoClient implements OAuthClient {
+
+	@Override
+	public ProviderType getProviderType() {
+		return ProviderType.KAKAO;
+	}
+
+	@Override
+	public String getAccessToken(String authorizationCode) {
+		return null;
+	}
+
+	@Override
+	public OAuthResponse getUserInfo(String accessToken) {
+		return null;
+	}
+}

--- a/src/main/java/com/ll/commars/domain/auth/oauth/client/NaverClient.java
+++ b/src/main/java/com/ll/commars/domain/auth/oauth/client/NaverClient.java
@@ -1,0 +1,22 @@
+package com.ll.commars.domain.auth.oauth.client;
+
+import com.ll.commars.domain.auth.dto.OAuthResponse;
+import com.ll.commars.domain.member.entity.ProviderType;
+
+public class NaverClient implements OAuthClient {
+
+	@Override
+	public ProviderType getProviderType() {
+		return ProviderType.NAVER;
+	}
+
+	@Override
+	public String getAccessToken(String authorizationCode) {
+		return null;
+	}
+
+	@Override
+	public OAuthResponse getUserInfo(String accessToken) {
+		return null;
+	}
+}

--- a/src/main/java/com/ll/commars/domain/auth/oauth/client/OAuthClient.java
+++ b/src/main/java/com/ll/commars/domain/auth/oauth/client/OAuthClient.java
@@ -1,0 +1,13 @@
+package com.ll.commars.domain.auth.oauth.client;
+
+import com.ll.commars.domain.auth.dto.OAuthResponse;
+import com.ll.commars.domain.member.entity.ProviderType;
+
+public interface OAuthClient {
+
+	ProviderType getProviderType();
+
+	String getAccessToken(String authorizationCode);
+
+	OAuthResponse getUserInfo(String accessToken);
+}

--- a/src/main/java/com/ll/commars/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/commars/domain/member/entity/Member.java
@@ -34,7 +34,7 @@ public class Member extends BaseEntity {
 
 	@Column
 	@Enumerated(EnumType.STRING)
-	private SocialProvider socialProvider;
+	private ProviderType providerType;
 
 	@Column(unique = true)
 	private String email;

--- a/src/main/java/com/ll/commars/domain/member/entity/ProviderType.java
+++ b/src/main/java/com/ll/commars/domain/member/entity/ProviderType.java
@@ -1,6 +1,6 @@
 package com.ll.commars.domain.member.entity;
 
-public enum SocialProvider {
+public enum ProviderType {
 
 	GOOGLE,
 	KAKAO,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- resolves: #8 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

OAuthService 추상 클래스를 만들고 이를 KakaoOAuthService 등이 상속하도록 구현하려고 했으나, 새로운 provider가 추가되면 따로 서비스 레이어를 작성해야 하는 불편함이 있다. 이에 전략 패턴을 사용한다. 각 provider의 로그인 로직을 캡슐화하고 메인 서비스가 상황에 따라 맞는 전략을 선택하도록 한다. OCP 또한 만족하게 된다.

모든 provider가 구현해야 하는 기능에 대한 명세인 OAuthClient 를 구현하고, 이를 구현한 KakaoClient 등을 작성한다. OAuthService 는 요청에 맞는 OAuthClient 를 찾아 작업을 위임하도록 한다.

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
